### PR TITLE
Add Spectacle functional tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-GAUGE testing GAUGE!
-====================
+# spectacle-functional-tests
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
-Tests for Gauge Command-Line Utility using Gauge
+## Functional tests for the [Spectacle Gauge plugin](https://github.com/getgauge/spectacle)
 
 ### Steps to get started
 - [Install Gauge](https://docs.gauge.org/getting_started/installing-gauge.html)
@@ -16,7 +15,6 @@ Tests for Gauge Command-Line Utility using Gauge
   ```
   gauge install java
   gauge install ruby
-  gauge install csharp
   gauge install dotnet
   gauge install python
   gauge install js
@@ -27,16 +25,25 @@ Tests for Gauge Command-Line Utility using Gauge
 - Executing specs
 
   ```
-  ./gradlew clean {language}FT # On Linux or Mac
-  gradlew.bat clean {language}FT # On Windows
+  ./gradlew clean spectacle{Language}FT # On Linux or Mac
+  gradlew.bat clean spectacle{Language}FT # On Windows
   ```
   ```
-  ./gradlew clean javaFT      # For Windows - gradlew.bat clean javaFT
-  ./gradlew clean javaFT      # For Windows - gradlew.bat clean javaFT
-  ./gradlew clean pythonFT    # For Windows - gradlew.bat clean pythonFT
-  ./gradlew clean rubyFT      # For Windows - gradlew.bat clean rubyFT
-  ./gradlew clean csharpFT    # For Windows - gradlew.bat clean csharpFT
-  ./gradlew clean dotnetFT    # For Windows - gradlew.bat clean dotnetFT
+  ./gradlew clean spectacleJavaFT      # For Windows - gradlew.bat clean spectacleJavaFT
+  ./gradlew clean spectacleRubyFT      # For Windows - gradlew.bat clean spectacleRubyFT
+  ./gradlew clean spectacleDotnetFT    # For Windows - gradlew.bat clean spectacleDotnetFT
+  ./gradlew clean spectaclePythonFT    # For Windows - gradlew.bat clean spectaclePythonFT
+  ./gradlew clean spectacleJsFT        # For Windows - gradlew.bat clean spectacleJsFT
   ```
 
 This will also compile all the supporting code implementations and run your specs in parallel.
+
+### Based on the [`getgauge/gauge-tests`](https://github.com/getgauge/gauge-tests) repository
+
+This spectacle-functional-tests repository was created by using the 
+[`getgauge/gauge-tests`](https://github.com/getgauge/gauge-tests) repository, which has the
+functional tests for Gauge itself, as a 
+[template](https://github.blog/2019-06-06-generate-new-repositories-with-repository-templates/).
+
+The functional tests use Gauge itself to perform the tests, just as the `gauge-tests` repository
+does.  This provides great end to end test coverage :-)

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ import com.thoughtworks.gauge.gradle.*
 
 def languages = ['java', 'js', 'csharp', 'dotnet', 'ruby', 'python']
 
+def plugins = ['spectacle']
+
 languages.each {lang ->
     task "${lang}FT" (type: GaugeTask) {
         doFirst {
@@ -35,6 +37,27 @@ languages.each {lang ->
                 env = "ci-${lang}"
                 tags = "${lang}"
             }
+        }
+    }
+
+    plugins.each {plugin ->
+        task "${plugin}${lang.capitalize()}FT" (type: GaugeTask) {
+            doFirst {
+                gauge {
+                    specsDir = 'specs'
+                    inParallel = true
+                    env = "ci-${lang}"
+                    tags = "${lang} & ${plugin}"
+                }
+            }
+        }
+    }
+}
+
+plugins.each {plugin ->
+    task "${plugin}FT" {
+        dependsOn {
+            languages.collect {"${plugin}${it.capitalize()}FT"}
         }
     }
 }

--- a/specs/plugins/documentation/spectacle/spectacle_basic_specs.spec
+++ b/specs/plugins/documentation/spectacle/spectacle_basic_specs.spec
@@ -1,0 +1,60 @@
+Spectacle spec with scenarios
+===============================
+
+tags: spectacle, java, dotnet, ruby, python, js
+
+* Initialize a project named "spec_with_scenarios" without example spec
+
+Basic spec with one scenario
+-------------------------------------
+
+* Create a scenario "Sample scenario" in specification "Basic spec execution" with the following steps with implementation 
+
+   |step text               |implementation                                          |
+   |------------------------|--------------------------------------------------------|
+   |First step              |"inside first step"                                     |
+   |Second step             |"inside second step"                                    |
+   |Third step              |"inside third step"                                     |
+   |Step with "two" "params"|"inside step with parameters : " + param0 + " " + param1|
+
+* Generate Spectacle Documentation for the current project
+
+* Console should contain "Succesfully converted specs to html"
+
+* Verify Spectacle Documentation
+
+|totalSpecificationsCount |totalScenariosCount |
+|-------------------------|--------------------|
+|1                        |1                   |
+
+
+Basic spec with multiple scenarios
+-------------------------------------------
+
+* Create a scenario "Sample scenario" in specification "Basic spec execution" with the following steps with implementation 
+
+   |step text          |implementation     |
+   |-------------------|-------------------|
+   |First Scenario step|"inside first step"|
+
+* Create a scenario "second scenario" in specification "Basic spec execution" with the following steps with implementation 
+
+   |step text           |implementation      |
+   |--------------------|--------------------|
+   |Second Scenario step|"inside second step"|
+
+* Create a scenario "third scenario" in specification "Basic spec execution" with the following steps with implementation 
+
+   |step text          |implementation     |
+   |-------------------|-------------------|
+   |Third Scenario step|"inside third step"|
+
+* Generate Spectacle Documentation for the current project
+
+* Console should contain "Succesfully converted specs to html"
+
+* Verify Spectacle Documentation
+
+|totalSpecificationsCount |totalScenariosCount |
+|-------------------------|--------------------|
+|1                        |3                   |

--- a/specs/plugins/documentation/spectacle/spectacle_multiple_specs_in_a_folder.spec
+++ b/specs/plugins/documentation/spectacle/spectacle_multiple_specs_in_a_folder.spec
@@ -1,0 +1,40 @@
+Spectacle multiple specs in a folder
+====================================
+
+tags: spectacle, java, dotnet, ruby, python, js
+
+* Initialize a project named "multiple_specs_in_folder" without example spec
+
+Document multiple specs in a folder
+------------------------------------
+
+* Create "scenario 1" in "Spec 1" within sub folder "specs" with the following steps 
+
+   |step text   |implementation      |
+   |------------|--------------------|
+   |First step1 |"inside first step" |
+   |Second step1|"inside second step"|
+
+* Create "scenario 2" in "Spec 2" within sub folder "specs" with the following steps 
+
+   |step text   |implementation      |
+   |------------|--------------------|
+   |First step2 |"inside first step" |
+   |Second step2|"inside second step"|
+
+* Create "scenario 3" in "Spec 3" within sub folder "specs" with the following steps 
+
+   |step text   |implementation      |
+   |------------|--------------------|
+   |First step3 |"inside first step" |
+   |Second step3|"inside second step"|
+
+* Generate Spectacle Documentation for the current project
+
+* Console should contain "Succesfully converted specs to html"
+
+* Verify Spectacle Documentation
+
+|totalSpecificationsCount |totalScenariosCount |
+|-------------------------|--------------------|
+|3                        |3                   |

--- a/specs/plugins/documentation/spectacle/verify_spectacle_documentation.cpt
+++ b/specs/plugins/documentation/spectacle/verify_spectacle_documentation.cpt
@@ -1,0 +1,2 @@
+# Verify Spectacle Documentation <statistics>
+* verify spectacle documentation statistics with <statistics>

--- a/src/test/java/com/thoughtworks/gauge/test/common/GaugeProject.java
+++ b/src/test/java/com/thoughtworks/gauge/test/common/GaugeProject.java
@@ -293,6 +293,12 @@ public abstract class GaugeProject {
         return execute(new String[]{"run", "--parallel", "-n=" + nStreams, "--verbose", "specs/"}, null);
     }
 
+    public ExecutionSummary generateSpectacleDocumentation() throws Exception {
+        String[] args = new String[]{"docs", "spectacle", "specs/"};
+        boolean success = executeGaugeCommand(args, null);
+        return new ExecutionSummary(String.join(" ", args), success, lastProcessStdout, lastProcessStderr);
+    }
+
     public ExecutionSummary validate() throws Exception {
         return execute(new String[]{"validate", "specs/"}, null);
     }

--- a/src/test/java/com/thoughtworks/gauge/test/implementation/Execution.java
+++ b/src/test/java/com/thoughtworks/gauge/test/implementation/Execution.java
@@ -187,4 +187,9 @@ public class Execution {
     public void repeatLastRun(Result argResult) throws Exception {
         assertOn(getCurrentProject().repeatLastRun(), argResult == Result.SUCCESS);
     }
+
+    @Step("Generate Spectacle Documentation for the current project")
+    public void generateSpectacleDocumentationForCurrentProject() throws Exception {
+        assertOn(getCurrentProject().generateSpectacleDocumentation(), true);
+    }
 }

--- a/src/test/java/com/thoughtworks/gauge/test/implementation/Spectacle.java
+++ b/src/test/java/com/thoughtworks/gauge/test/implementation/Spectacle.java
@@ -1,0 +1,67 @@
+package com.thoughtworks.gauge.test.implementation;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.thoughtworks.gauge.Step;
+import com.thoughtworks.gauge.Table;
+import com.thoughtworks.gauge.test.common.Util;
+import org.apache.commons.logging.LogFactory;
+import org.jsoup.Jsoup;
+import org.jsoup.select.Elements;
+import org.w3c.dom.Node;
+import se.fishtank.css.selectors.Selectors;
+import se.fishtank.css.selectors.dom.W3CNode;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.logging.Level;
+import static com.thoughtworks.gauge.test.common.GaugeProject.getCurrentProject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Spectacle {
+
+    @Step("verify spectacle documentation statistics with <statistics>")
+    public void verifyStatistics(Table statistics) throws IOException {
+        java.util.logging.Logger.getLogger("com.gargoylesoftware").setLevel(Level.OFF);
+        LogFactory.getFactory().setAttribute("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.NoOpLog");
+        java.util.logging.Logger.getLogger("org.apache.commons.httpclient").setLevel(Level.OFF);
+        final WebClient webClient = getWebClient();
+        String documentationPath = getSpectaclePath();
+        assertTrue(Files.exists(Paths.get(getCurrentProject().getProjectDir().getAbsolutePath())));
+        assertTrue(Files.exists(Paths.get(documentationPath)));
+        final HtmlPage page = webClient.getPage("file://" + documentationPath);
+        Selectors<Node, W3CNode>  selectors = new Selectors<>(new W3CNode(page.getDocumentElement()));
+        String expectedTotalSpecificationsCount = statistics.getTableRows().get(0).getCell("totalSpecificationsCount");
+        String actualTotalSpecificationsCount = selectors.querySelectorAll(".specs .stats .stat").get(0).getTextContent();
+        assertEquals("Total specifications count:", expectedTotalSpecificationsCount, actualTotalSpecificationsCount);
+        String expectedTotalScenariosCount = statistics.getTableRows().get(0).getCell("totalScenariosCount");
+        String actualTotalScenariosCount = selectors.querySelectorAll(".specs .stats .stat").get(1).getTextContent();
+        assertEquals("Total scenarios count:", expectedTotalScenariosCount, actualTotalScenariosCount);
+        
+    }
+
+    private String getSpectaclePath() {
+        return getSpectaclePath(null);
+    }
+
+    private String getSpectaclePath(String specName) {
+        String baseSpectaclePath = Util.combinePath(getCurrentProject().getProjectDir().getAbsolutePath(), "docs", "html");
+        if (specName == null)
+            return Util.combinePath(baseSpectaclePath, "index.html");
+        return Util.combinePath(baseSpectaclePath, "specs", specName + ".html");
+    }
+
+    private WebClient getWebClient() {
+        final WebClient webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnScriptError(false);
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        return webClient;
+    }
+    
+}


### PR DESCRIPTION
This commit adds basic functional tests for the [Spectacle plugin][1].
It will then be straightforward (in a subsequent pull request on the
Spectacle repo) to trigger these tests via a [GitHub Action][2] on every
push and pull request in the Spectacle repo.

This commit only adds a small number of functional tests with limited
coverage of Spectacle's functionality, but as these are the first
functional tests for Spectacle there is still significant
value from a regression prevention perspective.  Further tests can be
added in future commits if deemed useful.

The commit also provides a minimal framework for functional tests for
other plugins to be added in the future.  The Spectacle functional tests
in this commit serve as a useful example for anyone writing a future
plugin on how they can add functional tests.  To that end, it may
also be useful to make this spectacle-functional-tests repo a [template
repository][3], so that anyone writing a new Gauge plugin can easily use
this repo as a starting template for functional tests for their plugin,
should they wish.

[1]: https://github.com/getgauge/spectacle
[2]: https://github.com/features/actions
[3]: https://github.blog/2019-06-06-generate-new-repositories-with-repository-templates/

Signed-off-by: John Boyes <john@agilepathway.co.uk>